### PR TITLE
Add FOCIL metrics

### DIFF
--- a/focil.md
+++ b/focil.md
@@ -6,8 +6,8 @@ The following metrics are proposed to be added to clients for FOCIL monitoring. 
 |------|-------------|-------|-------------------------|--------|---------|
 | `beacon_inclusion_lists_valid_total`| Counter | Total number of valid inclusion lists | On inclusion list validation | **source:** gossip, api | |
 | `beacon_inclusion_lists_invalid_total`| Counter | Total number of invalid inclusion lists | On inclusion list validation | **source**: gossip, api; **reason**: unknown, [REJECT/IGNORE from specs](https://github.com/ethereum/consensus-specs/blob/master/specs/_features/eip7805/p2p-interface.md#inclusion_list) | |
-| `beacon_inclusion_lists_valid_size_bytes_total`| Counter | Total size of valid inclusion lists in bytes  | On inclusion list validation | | |
-| `beacon_inclusion_lists_invalid_size_bytes_total`| Counter | Total size of invalid inclusion lists in bytes  | On inclusion list validation | | |
+| `beacon_inclusion_lists_valid_size_bytes_total`| Counter | Total size of valid inclusion lists in bytes | On inclusion list validation | | |
+| `beacon_inclusion_lists_invalid_size_bytes_total`| Counter | Total size of invalid inclusion lists in bytes | On inclusion list validation | | |
 | `beacon_inclusion_lists_validation_time_seconds`| Histogram | Time taken to validate inclusion lists | On inclusion list validation | **source**: gossip, api | 0.1, 0.25, 0.5, 0.75, 1, 2 |
 | `beacon_inclusion_lists_received_total`| Counter | Total number of received inclusion lists | On receiving inclusion list | **source**: gossip, api | |
 | `beacon_inclusion_list_transactions_received_total`| Counter | Total number of transactions in received inclusion lists | On receiving inclusion list | **source**: gossip, api | |
@@ -15,9 +15,10 @@ The following metrics are proposed to be added to clients for FOCIL monitoring. 
 | `beacon_inclusion_lists_arrival_time_seconds`| Histogram | Inclusion list arrival time since the beginning of slot | On receiving inclusion list | | 0, 1, 2, 3, 4, 6, 8, 9, 10, 11, 12 |
 | `beacon_inclusion_lists_equivocating_total`| Counter | Total number of equivocating inclusion lists | Fork-choice `on_inclusion_list` | | |
 | `beacon_inclusion_list_unsatisfied_blocks_total`| Counter | Total number of unsatisfied inclusion list blocks | Fork-choice `on_block` | | |
-| `beacon_inclusion_list_transactions_sent_to_payload_total`| Counter | Total number of inclusion list transactions sent to payload | On `notify_new_payload` | | |
+| `beacon_inclusion_list_transactions_sent_to_engine_new_payload_total`| Counter | Total number of inclusion list transactions sent to new payload | On `notify_new_payload` | | |
+| `beacon_inclusion_list_transactions_sent_to_prepare_execution_payload_total`| Counter | Total number of inclusion list transactions sent to prepare execution payload | On `prepare_execution_payload` | | |
 | `beacon_engine_getInclusionListV1_requests_total`| Counter | Total number of engine_getInclusionListV1 requests sent | On `engine_getInclusionListV1` | | |
-| `beacon_engine_getInclusionListV1_requests_duration_seconds`| Histogram | Duration of engine_getInclusionListV1 requests| On `engine_getInclusionListV1` | | 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5 |
+| `beacon_engine_getInclusionListV1_requests_duration_seconds`| Histogram | Duration of engine_getInclusionListV1 requests | On `engine_getInclusionListV1` | | 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5 |
 
 ## Clients implementations
 
@@ -34,6 +35,7 @@ The following metrics are proposed to be added to clients for FOCIL monitoring. 
 | `beacon_inclusion_lists_arrival_time_seconds`| □ | □ | ✅ | □ | □ | □ |
 | `beacon_inclusion_lists_equivocating_total`| □ | □ | ✅ | □ | □ | □ |
 | `beacon_inclusion_list_unsatisfied_blocks_total`| □ | □ | ✅ | □ | □ | □ |
-| `beacon_inclusion_list_transactions_sent_to_payload_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_list_transactions_sent_to_engine_new_payload_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_list_transactions_sent_to_prepare_execution_payload_total`| □ | □ | ✅ | □ | □ | □ |
 | `beacon_engine_getInclusionListV1_requests_total`| □ | □ | ✅ | □ | □ | □ |
 | `beacon_engine_getInclusionListV1_requests_duration_seconds`| □ | □ | ✅ | □ | □ | □ |

--- a/focil.md
+++ b/focil.md
@@ -1,0 +1,15 @@
+# FOCIL Metrics
+
+The following metrics are proposed to be added to clients for FOCIL monitoring. This list is open for discussion. Each client has the opportunity to contribute to it by suggesting additions or disputing existing metrics.
+
+| Name | Metric type | Usage | Sample collection event |
+|--------------------------------------------|-------------|-------------------------------------------------------------|----------------------|
+| `beacon_inclusion_list_size_bytes_total`            | Counter   | Byte size of the inclusion list  |      |
+| `beacon_validated_inclusion_list_total`           | Counter   | Number of validated inclusion lists |      |
+| `beacon_inclusion_list_validation_time_milliseconds `  | Histogram | Total time to validate inclusion list  |  |
+| `beacon_get_inclusion_list_v1_total`           | Counter   | Number of requested inclusion lists |      |
+| `beacon_get_inclusion_list_v1_latency_milliseconds `  | Histogram | RPC latency for getInclusionListV1 |  |
+| `beacon_update_payload_with_inclusion_list_total`  | Counter   | Count the number of execution payloads with inclusion lists |    |
+| `beacon_update_payload_with_inclusion_list_v1_latency_milliseconds`  | Histogram | RPC latency for updatePayloadWithInclusionListV1   |   |
+| `beacon_inclusion_list_submitted_for_rpc_total`  | Counter   | Number of inclusion lists submitted for rpc |     |
+

--- a/focil.md
+++ b/focil.md
@@ -15,8 +15,8 @@ The following metrics are proposed to be added to clients for FOCIL monitoring. 
 | `beacon_inclusion_lists_arrival_time_seconds`| Histogram | Inclusion list arrival time since the beginning of slot | On receiving inclusion list | | 0, 1, 2, 3, 4, 6, 8, 9, 10, 11, 12 |
 | `beacon_inclusion_lists_equivocating_total`| Counter | Total number of equivocating inclusion lists | Fork-choice `on_inclusion_list` | | |
 | `beacon_inclusion_list_unsatisfied_blocks_total`| Counter | Total number of unsatisfied inclusion list blocks | Fork-choice `on_block` | | |
-| `beacon_inclusion_list_transactions_sent_to_engine_new_payload_total`| Counter | Total number of inclusion list transactions sent to new payload | On `notify_new_payload` | | |
-| `beacon_inclusion_list_transactions_sent_to_prepare_execution_payload_total`| Counter | Total number of inclusion list transactions sent to prepare execution payload | On `prepare_execution_payload` | | |
+| `beacon_inclusion_list_transactions_notify_new_payload_total`| Counter | Total number of inclusion list transactions sent when notifying new payload | On `notify_new_payload` | | |
+| `beacon_inclusion_list_transactions_prepare_execution_payload_total`| Counter | Total number of inclusion list transactions sent when preparing execution payload | On `prepare_execution_payload` | | |
 | `beacon_engine_getInclusionListV1_requests_total`| Counter | Total number of engine_getInclusionListV1 requests sent | On `engine_getInclusionListV1` | | |
 | `beacon_engine_getInclusionListV1_requests_duration_seconds`| Histogram | Duration of engine_getInclusionListV1 requests | On `engine_getInclusionListV1` | | 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5 |
 
@@ -35,7 +35,7 @@ The following metrics are proposed to be added to clients for FOCIL monitoring. 
 | `beacon_inclusion_lists_arrival_time_seconds`| □ | □ | ✅ | □ | □ | □ |
 | `beacon_inclusion_lists_equivocating_total`| □ | □ | ✅ | □ | □ | □ |
 | `beacon_inclusion_list_unsatisfied_blocks_total`| □ | □ | ✅ | □ | □ | □ |
-| `beacon_inclusion_list_transactions_sent_to_engine_new_payload_total`| □ | □ | ✅ | □ | □ | □ |
-| `beacon_inclusion_list_transactions_sent_to_prepare_execution_payload_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_list_transactions_notify_new_payload_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_list_transactions_prepare_execution_payload_total`| □ | □ | ✅ | □ | □ | □ |
 | `beacon_engine_getInclusionListV1_requests_total`| □ | □ | ✅ | □ | □ | □ |
 | `beacon_engine_getInclusionListV1_requests_duration_seconds`| □ | □ | ✅ | □ | □ | □ |

--- a/focil.md
+++ b/focil.md
@@ -6,13 +6,11 @@ The following metrics are proposed to be added to clients for FOCIL monitoring. 
 |--------------------------------------------|-------------|-------------------------------------------------------------|----------------------|
 | `beacon_inclusion_lists_size_bytes_total`            | Counter   | Byte size of the inclusion list  |      |
 | `beacon_inclusion_lists_validated_total`           | Counter   | Number of validated inclusion lists |      |
-| `beacon_inclusion_lists_validation_time_{time_units}`  | Histogram | Time to validate inclusion list  |  |
+| `beacon_inclusion_lists_validation_time_seconds`  | Histogram | Time to validate inclusion list  |  |
 | `beacon_get_inclusion_list_v1_total`           | Counter   | Number of getInclusionListV1 requests |      |
-| `beacon_get_inclusion_list_v1_latency_{time_units}`  | Histogram | Latency for getInclusionListV1 |  |
+| `beacon_get_inclusion_list_v1_latency_seconds`  | Histogram | Latency for getInclusionListV1 |  |
 | `beacon_update_payload_with_inclusion_list_v1_total`  | Counter   | Number of updatePayloadWithInclusionListV1 requests |    |
-| `beacon_update_payload_with_inclusion_list_v1_latency_{time_units}`  | Histogram | Latency for updatePayloadWithInclusionListV1   |   |
+| `beacon_update_payload_with_inclusion_list_v1_latency_seconds`  | Histogram | Latency for updatePayloadWithInclusionListV1   |   |
 | `beacon_inclusion_lists_submitted_for_rpc_total`  | Counter   | Number of inclusion lists submitted for RPC |     |
 | `beacon_inclusion_lists_cached_total`  | Counter   | Number of cached inclusion lists in slot N-1 |     |
 
-\* Clients are free to choose either `seconds` or `milliseconds` for `{time_units}`.
-For example: `beacon_data_availability_reconstruction_time_seconds` or `beacon_inclusion_list_validation_time_milliseconds`.

--- a/focil.md
+++ b/focil.md
@@ -4,12 +4,15 @@ The following metrics are proposed to be added to clients for FOCIL monitoring. 
 
 | Name | Metric type | Usage | Sample collection event |
 |--------------------------------------------|-------------|-------------------------------------------------------------|----------------------|
-| `beacon_inclusion_list_size_bytes_total`            | Counter   | Byte size of the inclusion list  |      |
-| `beacon_validated_inclusion_list_total`           | Counter   | Number of validated inclusion lists |      |
-| `beacon_inclusion_list_validation_time_milliseconds `  | Histogram | Total time to validate inclusion list  |  |
-| `beacon_get_inclusion_list_v1_total`           | Counter   | Number of requested inclusion lists |      |
-| `beacon_get_inclusion_list_v1_latency_milliseconds `  | Histogram | RPC latency for getInclusionListV1 |  |
-| `beacon_update_payload_with_inclusion_list_total`  | Counter   | Count the number of execution payloads with inclusion lists |    |
-| `beacon_update_payload_with_inclusion_list_v1_latency_milliseconds`  | Histogram | RPC latency for updatePayloadWithInclusionListV1   |   |
-| `beacon_inclusion_list_submitted_for_rpc_total`  | Counter   | Number of inclusion lists submitted for rpc |     |
+| `beacon_inclusion_lists_size_bytes_total`            | Counter   | Byte size of the inclusion list  |      |
+| `beacon_inclusion_lists_validated_total`           | Counter   | Number of validated inclusion lists |      |
+| `beacon_inclusion_lists_validation_time_{time_units}`  | Histogram | Time to validate inclusion list  |  |
+| `beacon_get_inclusion_list_v1_total`           | Counter   | Number of getInclusionListV1 requests |      |
+| `beacon_get_inclusion_list_v1_latency_{time_units}`  | Histogram | Latency for getInclusionListV1 |  |
+| `beacon_update_payload_with_inclusion_list_v1_total`  | Counter   | Number of updatePayloadWithInclusionListV1 requests |    |
+| `beacon_update_payload_with_inclusion_list_v1_latency_{time_units}`  | Histogram | Latency for updatePayloadWithInclusionListV1   |   |
+| `beacon_inclusion_lists_submitted_for_rpc_total`  | Counter   | Number of inclusion lists submitted for RPC |     |
+| `beacon_inclusion_lists_cached_total`  | Counter   | Number of cached inclusion lists in slot N-1 |     |
 
+\* Clients are free to choose either `seconds` or `milliseconds` for `{time_units}`.
+For example: `beacon_data_availability_reconstruction_time_seconds` or `beacon_inclusion_list_validation_time_milliseconds`.

--- a/focil.md
+++ b/focil.md
@@ -2,15 +2,38 @@
 
 The following metrics are proposed to be added to clients for FOCIL monitoring. This list is open for discussion. Each client has the opportunity to contribute to it by suggesting additions or disputing existing metrics.
 
-| Name | Metric type | Usage | Sample collection event |
-|--------------------------------------------|-------------|-------------------------------------------------------------|----------------------|
-| `beacon_inclusion_lists_size_bytes_total`            | Counter   | Byte size of the inclusion list  |      |
-| `beacon_inclusion_lists_validated_total`           | Counter   | Number of validated inclusion lists |      |
-| `beacon_inclusion_lists_validation_time_seconds`  | Histogram | Time to validate inclusion list  |  |
-| `beacon_get_inclusion_list_v1_total`           | Counter   | Number of getInclusionListV1 requests |      |
-| `beacon_get_inclusion_list_v1_latency_seconds`  | Histogram | Latency for getInclusionListV1 |  |
-| `beacon_update_payload_with_inclusion_list_v1_total`  | Counter   | Number of updatePayloadWithInclusionListV1 requests |    |
-| `beacon_update_payload_with_inclusion_list_v1_latency_seconds`  | Histogram | Latency for updatePayloadWithInclusionListV1   |   |
-| `beacon_inclusion_lists_submitted_for_rpc_total`  | Counter   | Number of inclusion lists submitted for RPC |     |
-| `beacon_inclusion_lists_cached_total`  | Counter   | Number of cached inclusion lists in slot N-1 |     |
+| Name | Metric type | Usage | Sample collection event | Labels | Buckets |
+|------|-------------|-------|-------------------------|--------|---------|
+| `beacon_inclusion_lists_valid_total`| Counter | Total number of valid inclusion lists | On inclusion list validation | **source:** gossip, api | |
+| `beacon_inclusion_lists_invalid_total`| Counter | Total number of invalid inclusion lists | On inclusion list validation | **source**: gossip, api; **reason**: unknown, [REJECT/IGNORE from specs](https://github.com/ethereum/consensus-specs/blob/master/specs/_features/eip7805/p2p-interface.md#inclusion_list) | |
+| `beacon_inclusion_lists_valid_size_bytes_total`| Counter | Total size of valid inclusion lists in bytes  | On inclusion list validation | | |
+| `beacon_inclusion_lists_invalid_size_bytes_total`| Counter | Total size of invalid inclusion lists in bytes  | On inclusion list validation | | |
+| `beacon_inclusion_lists_validation_time_seconds`| Histogram | Time taken to validate inclusion lists | On inclusion list validation | **source**: gossip, api | 0.1, 0.25, 0.5, 0.75, 1, 2 |
+| `beacon_inclusion_lists_received_total`| Counter | Total number of received inclusion lists | On receiving inclusion list | **source**: gossip, api | |
+| `beacon_inclusion_list_transactions_received_total`| Counter | Total number of transactions in received inclusion lists | On receiving inclusion list | **source**: gossip, api | |
+| `beacon_inclusion_lists_published_total`| Counter | Total number of published inclusion lists | On publishing inclusion list | | |
+| `beacon_inclusion_lists_arrival_time_seconds`| Histogram | Inclusion list arrival time since the beginning of slot | On receiving inclusion list | | 0, 1, 2, 3, 4, 6, 8, 9, 10, 11, 12 |
+| `beacon_inclusion_lists_equivocating_total`| Counter | Total number of equivocating inclusion lists | Fork-choice `on_inclusion_list` | | |
+| `beacon_inclusion_list_unsatisfied_blocks_total`| Counter | Total number of unsatisfied inclusion list blocks | Fork-choice `on_block` | | |
+| `beacon_inclusion_list_transactions_sent_to_payload_total`| Counter | Total number of inclusion list transactions sent to payload | On `notify_new_payload` | | |
+| `beacon_engine_getInclusionListV1_requests_total`| Counter | Total number of engine_getInclusionListV1 requests sent | On `engine_getInclusionListV1` | | |
+| `beacon_engine_getInclusionListV1_requests_duration_seconds`| Histogram | Duration of engine_getInclusionListV1 requests| On `engine_getInclusionListV1` | | 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5 |
 
+## Clients implementations
+
+| Metric | Grandine | Lighthouse | Lodestar | Nimbus | Prysm | Teku |
+|--------|----------|------------|----------|--------|-------|------|
+| `beacon_inclusion_lists_valid_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_lists_invalid_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_lists_valid_size_bytes_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_lists_invalid_size_bytes_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_lists_validation_time_seconds`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_lists_received_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_list_transactions_received_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_lists_published_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_lists_arrival_time_seconds`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_lists_equivocating_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_list_unsatisfied_blocks_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_inclusion_list_transactions_sent_to_payload_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_engine_getInclusionListV1_requests_total`| □ | □ | ✅ | □ | □ | □ |
+| `beacon_engine_getInclusionListV1_requests_duration_seconds`| □ | □ | ✅ | □ | □ | □ |


### PR DESCRIPTION
This PR introduces the list of the recommended metrics for monitoring FOCIL.

Issues #11, #15

| Name | Metric type | Usage |
|------|-------------|-------|
| `beacon_inclusion_lists_valid_total`| Counter | Total number of valid inclusion lists |
| `beacon_inclusion_lists_invalid_total`| Counter | Total number of invalid inclusion lists |
| `beacon_inclusion_lists_valid_size_bytes_total`| Counter | Total size of valid inclusion lists in bytes |
| `beacon_inclusion_lists_invalid_size_bytes_total`| Counter | Total size of invalid inclusion lists in bytes | 
| `beacon_inclusion_lists_validation_time_seconds`| Histogram | Time taken to validate inclusion lists |
| `beacon_inclusion_lists_received_total`| Counter | Total number of received inclusion lists |
| `beacon_inclusion_list_transactions_received_total`| Counter | Total number of transactions in received inclusion lists |
| `beacon_inclusion_lists_published_total`| Counter | Total number of published inclusion lists |
| `beacon_inclusion_lists_arrival_time_seconds`| Histogram | Inclusion list arrival time since the beginning of slot |
| `beacon_inclusion_lists_equivocating_total`| Counter | Total number of equivocating inclusion lists |
| `beacon_inclusion_list_unsatisfied_blocks_total`| Counter | Total number of unsatisfied inclusion list blocks |
| `beacon_inclusion_list_transactions_sent_to_payload_total`| Counter | Total number of inclusion list transactions sent to payload |
| `beacon_engine_getInclusionListV1_requests_total`| Counter | Total number of engine_getInclusionListV1 requests sent |
| `beacon_engine_getInclusionListV1_requests_duration_seconds`| Histogram | Duration of engine_getInclusionListV1 requests |

### Clients implementations

| Metric | Grandine | Lighthouse | Lodestar | Nimbus | Prysm | Teku |
|--------|----------|------------|----------|--------|-------|------|
| `beacon_inclusion_lists_valid_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_lists_invalid_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_lists_valid_size_bytes_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_lists_invalid_size_bytes_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_lists_validation_time_seconds`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_lists_received_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_list_transactions_received_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_lists_published_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_lists_arrival_time_seconds`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_lists_equivocating_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_list_unsatisfied_blocks_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_inclusion_list_transactions_sent_to_payload_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_engine_getInclusionListV1_requests_total`| □ | □ | ✅ | □ | □ | □ |
| `beacon_engine_getInclusionListV1_requests_duration_seconds`| □ | □ | ✅ | □ | □ | □ |

